### PR TITLE
Add support for LargeBotQueue as an alternative queue backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
+checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
 dependencies = [
  "memchr",
 ]
@@ -52,9 +52,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cfg-if"
@@ -483,18 +483,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -567,9 +567,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
 
 [[package]]
 name = "reqwest"
@@ -665,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -762,9 +762,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -906,6 +906,7 @@ dependencies = [
  "pretty_env_logger",
  "tokio",
  "twilight-gateway-queue 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twilight-http",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.1.0"
 
 [dependencies]
 twilight-gateway-queue = "0.1"
+twilight-http = "0.1"
 hyper = "0.13"
 log = "0.4"
 pretty_env_logger = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let host = IpAddr::from_str(&host_raw)?;
     let port = env::var("PORT").unwrap_or_else(|_| "80".into()).parse()?;
 
-    let queue: Arc<Box<dyn Queue>> = match env::var("TOKEN") {
-        Ok(token) => {
+    let queue: Arc<Box<dyn Queue>> = {
+        if let Ok(token) = env::var("DISCORD_TOKEN") {
             let http_client = Client::new(token);
             let gateway = http_client
                 .gateway()
@@ -47,8 +47,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 )
                 .await,
             ))
+        } else {
+            Arc::new(Box::new(LocalQueue::new()))
         }
-        Err(_) => Arc::new(Box::new(LocalQueue::new())),
     };
 
     let address = SocketAddr::from((host, port));

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,15 @@ use hyper::{
 };
 use log::{debug, error, info};
 use std::{
+    convert::TryInto,
     env,
     error::Error,
     net::{IpAddr, SocketAddr},
     str::FromStr,
+    sync::Arc,
 };
-use twilight_gateway_queue::{LocalQueue, Queue};
+use twilight_gateway_queue::{LargeBotQueue, LocalQueue, Queue};
+use twilight_http::Client;
 
 const PROCESSED: &[u8] = br#"{"message": "You're free to connect now! :)"}"#;
 
@@ -25,7 +28,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let host = IpAddr::from_str(&host_raw)?;
     let port = env::var("PORT").unwrap_or_else(|_| "80".into()).parse()?;
 
-    let queue = LocalQueue::new();
+    let queue: Arc<Box<dyn Queue>> = match env::var("TOKEN") {
+        Ok(token) => {
+            let http_client = Client::new(token);
+            let gateway = http_client
+                .gateway()
+                .authed()
+                .await
+                .expect("Cannot fetch gateway information");
+            Arc::new(Box::new(
+                LargeBotQueue::new(
+                    gateway
+                        .session_start_limit
+                        .max_concurrency
+                        .try_into()
+                        .unwrap(),
+                    &http_client,
+                )
+                .await,
+            ))
+        }
+        Err(_) => Arc::new(Box::new(LocalQueue::new())),
+    };
 
     let address = SocketAddr::from((host, port));
 


### PR DESCRIPTION
This adds a LargeBotQueue backend as the non-default backend.

The alternative and probably superior backend will be used if a `DISCORD_TOKEN` enviroment variable is provided, if not, a LocalQueue will be used. It will fetch max_concurrency from the Discord API and build the appropiate queue then.

This is backwards compatible as the old behavior is the same as the new one as this will only be used if the enviroment variable is present.

```sh
$ PORT=8080 ./target/release/twilight-gateway-queue
 2020-10-16T11:42:35.215Z INFO  twilight_gateway_queue > Listening on http://0.0.0.0:8080
 2020-10-16T11:42:42.404Z INFO  twilight_gateway_queue > shard 0/0 waiting for allowance
$ PORT=8080 DISCORD_TOKEN="snip" ./target/release/twilight-gateway-queue
 2020-10-16T11:42:56.412Z INFO  twilight_gateway_queue > Listening on http://0.0.0.0:8080
 2020-10-16T11:42:58.206Z INFO  twilight_gateway_queue::large_bot_queue > waiting for allowance on shard 0 
```