### PR TITLE
ci: prepare GitHub actions config to push to dockerhub organization account

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,9 @@ jobs:
   build:
     name: Build & publish
     env:
-      DOCKER_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
       DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKER_TARGET_ACCOUNT: ${{ secrets.DOCKERHUB_TARGET }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -20,19 +21,19 @@ jobs:
         if: env.DOCKER_USERNAME
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build for x86_64
         run: |
-            docker build -t twilight-gateway-queue:amd64 .
+            docker build -t gateway-queue:amd64 .
       - name: Build for aarch64
         run: |
-            docker build --no-cache --build-arg RUST_TARGET=aarch64-unknown-linux-musl --build-arg MUSL_TARGET=aarch64-linux-musl --build-arg FINAL_TARGET=arm64v8 -t twilight-gateway-queue:armv8 .
+            docker build --no-cache --build-arg RUST_TARGET=aarch64-unknown-linux-musl --build-arg MUSL_TARGET=aarch64-linux-musl --build-arg FINAL_TARGET=arm64v8 -t gateway-queue:armv8 .
       - name: Create manifest and push it
         if: env.DOCKER_USERNAME
         run: |
-            docker tag twilight-gateway-queue:amd64 ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:amd64
-            docker tag twilight-gateway-queue:armv8 ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:armv8
-            docker push ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:amd64
-            docker push ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:armv8
-            docker manifest create ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:latest ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:amd64 ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:armv8
-            docker manifest push ${{ secrets.DOCKERHUB_USERNAME }}/twilight-gateway-queue:latest
+            docker tag gateway-queue:amd64 ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:amd64
+            docker tag gateway-queue:armv8 ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:armv8
+            docker push ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:amd64
+            docker push ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:armv8
+            docker manifest create ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:latest ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:amd64 ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:armv8
+            docker manifest push ${{ secrets.DOCKERHUB_TARGET }}/gateway-queue:latest


### PR DESCRIPTION
This changes `DOCKERHUB_TOKEN` to `DOCKERHUB_PASSWORD` for the CI secrets as that is more accurate and prepares pushing to https://hub.docker.com/r/twilightrs/gateway-queue by adding a `DOCKERHUB_TARGET` secret that can be set to twilightrs to push there instead of to a personal account.