### PR TITLE
Fix grammar and punctuation mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,42 +6,44 @@ If your bot's shards are multi-processed, then a good choice is to use the
 [Gateway Queue]. The Gateway Queue is a lightweight but powerful application
 that you can host to queue shards across all of your processes.
 
-The Gateway Queue is library and language agnostic: it's an HTTP server that you
+The Gateway Queue is library and language agnostic, it's an HTTP server that you
 call whenever a shard needs to reconnect to the gateway.
 
 ### How it works
 
-When one of your shards disconnects and needs to perform a full reconnect, then
-it needs to start a new session with the gateway. If you have multiple processes
-managing shards, then you may not have communication between these processes.
-The problems start to happen when multiple shards from these processes try to
-reconnect at the same time: all but 1 will get ratelimited.
+When one of your shards disconnects and needs to perform a full reconnect, it
+needs to start a new session with the gateway. If you have multiple processes
+managing shards, you may not have communication between these processes. The
+problems start to happen when multiple shards from these processes try to
+reconnect at the same time, all but 1 will get rate-limited.
 
 This is because there's a 5 second ratelimit between new sessions. By sending an
 HTTP request to the Gateway Queue, it will ratelimit the requests and "stall"
 them, responding with a friendly message once that shard can reconnect:
 
 ```json
-{"message": "You're free to connect now! :)"}
+{
+  "message": "You're free to connect now! :)"
+}
 ```
 
 ### Example
 
-The API is pretty minimal, probably. It's just an HTTP request:
+The API is pretty minimal. It's just an HTTP request:
 
 ```rust
 reqwest::get("http://gateway-queue").await?;
 ```
 
-No headers, body, or particular method need to be set. They're all ignored.
+No headers, body, or particular method need to be set, they're all ignored.
 The request will get a response once the request has gone through the queue.
 
 ### Using with large bots
 
-If the bot has access to bucketed identify you will have to make slight
+If the bot has access to bucketed identify, you will have to make slight
 configuration changes. Firstly you will need to set the `DISCORD_TOKEN`
-environment variable so it is able to fetch the remaining identifies and what
-the `max_concurrency` is. Secondly you will need to set the query parameter
+environment variable so that it is able to fetch the remaining identifies and what
+the `max_concurrency` is. Secondly, you will need to set the query parameter
 `shard` to the ID of the identifying shard.
 
 ```rust


### PR DESCRIPTION
This includes some more subjective changes of what I think makes the `README` easier to read, also includes formatted JSON